### PR TITLE
Make onos-karaf properly pass arguments to onos-setup-karaf

### DIFF
--- a/tools/dev/bin/onos-karaf
+++ b/tools/dev/bin/onos-karaf
@@ -4,4 +4,4 @@
 # karaf using the supplied arguments.
 # -----------------------------------------------------------------------------
 
-onos-setup-karaf && karaf "$@"
+onos-setup-karaf "$@" && karaf "$@"


### PR DESCRIPTION
Without this change, onos-setup-karaf never got the "clean" argument
and thus never copied the package configs over the way it is supposed
to.

This will be necessary to configure the PortStatsPollFrequency and enable our SocketServer to get enough stats for our demos.