### PR TITLE
DeviceProvider: add enable/disablePort functions

### DIFF
--- a/cli/src/main/java/org/onosproject/cli/net/AnnotateDeviceCommand.java
+++ b/cli/src/main/java/org/onosproject/cli/net/AnnotateDeviceCommand.java
@@ -22,6 +22,7 @@ import org.onosproject.net.DefaultAnnotations;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.device.DefaultDeviceDescription;
 import org.onosproject.net.device.DeviceDescription;
 import org.onosproject.net.device.DeviceProvider;
@@ -99,6 +100,14 @@ public class AnnotateDeviceCommand extends AbstractShellCommand {
         @Override
         public boolean isReachable(DeviceId deviceId) {
             return false;
+        }
+
+        @Override
+        public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        }
+
+        @Override
+        public void disablePort(DeviceId deviceId, PortNumber portNumber) {
         }
     }
 }

--- a/core/api/src/main/java/org/onosproject/net/device/DeviceAdminService.java
+++ b/core/api/src/main/java/org/onosproject/net/device/DeviceAdminService.java
@@ -16,6 +16,7 @@
 package org.onosproject.net.device;
 
 import org.onosproject.net.DeviceId;
+import org.onosproject.net.PortNumber;
 
 /**
  * Service for administering the inventory of infrastructure devices.
@@ -30,5 +31,21 @@ public interface DeviceAdminService extends DeviceService {
     void removeDevice(DeviceId deviceId);
 
     // TODO: add ability to administratively suspend/resume device
+
+    /**
+     * Disables the given port.
+     *
+     * @param deviceId device identifier
+     * @param portNumber port number
+     */
+    void disablePort(DeviceId deviceId, PortNumber portNumber);
+
+    /**
+     * Enables the given port.
+     *
+     * @param deviceId device identifier
+     * @param portNumber port number
+     */
+    void enablePort(DeviceId deviceId, PortNumber portNumber);
 
 }

--- a/core/api/src/main/java/org/onosproject/net/device/DeviceProvider.java
+++ b/core/api/src/main/java/org/onosproject/net/device/DeviceProvider.java
@@ -17,6 +17,7 @@ package org.onosproject.net.device;
 
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.provider.Provider;
 
 /**
@@ -54,4 +55,20 @@ public interface DeviceProvider extends Provider {
      * @return true if reachable, false otherwise
      */
     boolean isReachable(DeviceId deviceId);
+
+    /**
+     * Enables the given port.
+     *
+     * @param deviceId device identifier
+     * @param portNumber port number
+     */
+    void enablePort(DeviceId deviceId, PortNumber portNumber);
+
+    /**
+     * Disables the given port.
+     *
+     * @param deviceId device identifier
+     * @param portNumber port number
+     */
+    void disablePort(DeviceId deviceId, PortNumber portNumber);
 }

--- a/core/net/src/main/java/org/onosproject/net/device/impl/DeviceManager.java
+++ b/core/net/src/main/java/org/onosproject/net/device/impl/DeviceManager.java
@@ -247,6 +247,32 @@ public class DeviceManager
     }
 
     @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO check permission?
+        checkNotNull(deviceId, DEVICE_ID_NULL);
+        checkNotNull(portNumber, PORT_NUMBER_NULL);
+
+        DeviceProvider provider = getProvider(deviceId);
+        if (provider == null) {
+            return;
+        }
+        provider.disablePort(deviceId, portNumber);
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO check permission?
+        checkNotNull(deviceId, DEVICE_ID_NULL);
+        checkNotNull(portNumber, PORT_NUMBER_NULL);
+
+        DeviceProvider provider = getProvider(deviceId);
+        if (provider == null) {
+            return;
+        }
+        provider.enablePort(deviceId, portNumber);
+    }
+
+    @Override
     protected DeviceProviderService createProviderService(
             DeviceProvider provider) {
         return new InternalDeviceProviderService(provider);

--- a/core/net/src/test/java/org/onosproject/net/device/impl/DeviceManagerTest.java
+++ b/core/net/src/test/java/org/onosproject/net/device/impl/DeviceManagerTest.java
@@ -274,6 +274,16 @@ public class DeviceManagerTest {
         public boolean isReachable(DeviceId device) {
             return false;
         }
+
+        @Override
+        public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
+        }
+
+        @Override
+        public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
+        }
     }
 
     private static class TestListener implements DeviceListener {

--- a/incubator/rpc-grpc/src/main/java/org/onosproject/incubator/rpc/grpc/GrpcRemoteServiceServer.java
+++ b/incubator/rpc-grpc/src/main/java/org/onosproject/incubator/rpc/grpc/GrpcRemoteServiceServer.java
@@ -51,6 +51,7 @@ import org.onosproject.grpc.DeviceProviderRegistryRpcGrpc.DeviceProviderRegistry
 import org.onosproject.grpc.LinkProviderServiceRpcGrpc;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.device.DeviceProvider;
 import org.onosproject.net.device.DeviceProviderRegistry;
 import org.onosproject.net.device.DeviceProviderService;
@@ -428,6 +429,16 @@ public class GrpcRemoteServiceServer {
             }
             return false;
             // TODO Catch Exceptions and call onError()
+        }
+
+        @Override
+        public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+            //TODO
+        }
+
+        @Override
+        public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+            //TODO
         }
 
         @Override

--- a/incubator/rpc-grpc/src/test/java/org/onosproject/incubator/rpc/grpc/GrpcRemoteServiceTest.java
+++ b/incubator/rpc-grpc/src/test/java/org/onosproject/incubator/rpc/grpc/GrpcRemoteServiceTest.java
@@ -369,6 +369,16 @@ public class GrpcRemoteServiceTest {
             return isReachableReply;
         }
 
+        @Override
+        public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
+        }
+
+        @Override
+        public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
+        }
+
     }
 
     class NoOpRemoteServiceProviderRegistry

--- a/providers/bgp/topology/src/main/java/org/onosproject/provider/bgp/topology/impl/BgpTopologyProvider.java
+++ b/providers/bgp/topology/src/main/java/org/onosproject/provider/bgp/topology/impl/BgpTopologyProvider.java
@@ -29,6 +29,7 @@ import org.onosproject.bgpio.protocol.linkstate.BgpNodeLSNlriVer4;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.device.DefaultDeviceDescription;
 import org.onosproject.net.device.DeviceDescription;
 import org.onosproject.net.device.DeviceProvider;
@@ -121,5 +122,15 @@ public class BgpTopologyProvider extends AbstractProvider implements DeviceProvi
     public boolean isReachable(DeviceId deviceId) {
         // TODO Auto-generated method stub
         return true;
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        // TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        // TODO
     }
 }

--- a/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
+++ b/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
@@ -31,6 +31,7 @@ import org.onosproject.net.DefaultAnnotations;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.SparseAnnotations;
 import org.onosproject.net.behaviour.PortDiscovery;
 import org.onosproject.net.config.ConfigFactory;
@@ -160,6 +161,16 @@ public class NetconfDeviceProvider extends AbstractProvider
             return false;
         }
         return netconfDevice.isActive();
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
     }
 
     private class InnerNetconfDeviceListener implements NetconfDeviceListener {

--- a/providers/null/src/main/java/org/onosproject/provider/nil/NullProviders.java
+++ b/providers/null/src/main/java/org/onosproject/provider/nil/NullProviders.java
@@ -32,6 +32,7 @@ import org.onosproject.net.ConnectPoint;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.Host;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.device.DeviceAdminService;
 import org.onosproject.net.device.DeviceProvider;
 import org.onosproject.net.device.DeviceProviderRegistry;
@@ -426,6 +427,16 @@ public class NullProviders {
             return topoShape.equals("configured") ||
                     (simulator != null && simulator.contains(deviceId) &&
                             topologyMutationDriver.isReachable(deviceId));
+        }
+
+        @Override
+        public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
+        }
+
+        @Override
+        public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+            // TODO
         }
 
         @Override

--- a/providers/ovsdb/device/src/main/java/org/onosproject/ovsdb/providers/device/OvsdbDeviceProvider.java
+++ b/providers/ovsdb/device/src/main/java/org/onosproject/ovsdb/providers/device/OvsdbDeviceProvider.java
@@ -32,6 +32,7 @@ import org.onosproject.net.DefaultAnnotations;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.SparseAnnotations;
 import org.onosproject.net.device.DefaultDeviceDescription;
 import org.onosproject.net.device.DeviceDescription;
@@ -108,6 +109,16 @@ public class OvsdbDeviceProvider extends AbstractProvider
     public boolean isReachable(DeviceId deviceId) {
         OvsdbClientService ovsdbClient = controller.getOvsdbClient(changeDeviceIdToNodeId(deviceId));
         return !(ovsdbClient == null || !ovsdbClient.isConnected());
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
     }
 
     private class InnerOvsdbNodeListener implements OvsdbNodeListener {

--- a/providers/pcep/topology/src/main/java/org/onosproject/provider/pcep/topology/impl/PcepTopologyProvider.java
+++ b/providers/pcep/topology/src/main/java/org/onosproject/provider/pcep/topology/impl/PcepTopologyProvider.java
@@ -34,6 +34,7 @@ import org.onosproject.net.OchPort;
 import org.onosproject.net.OduCltPort;
 import org.onosproject.net.OmsPort;
 import org.onosproject.net.Port;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.device.DefaultDeviceDescription;
 import org.onosproject.net.device.DefaultPortDescription;
 import org.onosproject.net.device.DeviceDescription;
@@ -317,5 +318,15 @@ public class PcepTopologyProvider extends AbstractProvider
     public boolean isReachable(DeviceId deviceId) {
         // TODO Auto-generated method stub
         return true;
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        // TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        // TODO
     }
 }

--- a/providers/rest/device/src/main/java/org/onosproject/provider/rest/device/impl/RestDeviceProvider.java
+++ b/providers/rest/device/src/main/java/org/onosproject/provider/rest/device/impl/RestDeviceProvider.java
@@ -31,6 +31,7 @@ import org.onosproject.net.DefaultAnnotations;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.SparseAnnotations;
 import org.onosproject.net.behaviour.PortDiscovery;
 import org.onosproject.net.config.ConfigFactory;
@@ -171,6 +172,16 @@ public class RestDeviceProvider extends AbstractProvider
             return false;
         }
         return restDevice.isActive();
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
     }
 
     private void deviceAdded(RestSBDevice nodeId) {

--- a/providers/snmp/device/src/main/java/org/onosproject/provider/snmp/device/impl/SnmpDeviceProvider.java
+++ b/providers/snmp/device/src/main/java/org/onosproject/provider/snmp/device/impl/SnmpDeviceProvider.java
@@ -37,6 +37,7 @@ import org.onosproject.net.DefaultAnnotations;
 import org.onosproject.net.Device;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.MastershipRole;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.SparseAnnotations;
 import org.onosproject.net.behaviour.PortDiscovery;
 import org.onosproject.net.device.DefaultDeviceDescription;
@@ -277,6 +278,16 @@ public class SnmpDeviceProvider extends AbstractProvider
             return false;
         }
         return snmpDevice.isReachable();
+    }
+
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
     }
 
     /**

--- a/web/api/src/main/java/org/onosproject/rest/resources/ConfigProvider.java
+++ b/web/api/src/main/java/org/onosproject/rest/resources/ConfigProvider.java
@@ -577,6 +577,16 @@ class ConfigProvider implements DeviceProvider, LinkProvider, HostProvider {
         return true;
     }
 
+    @Override
+    public void enablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
+    @Override
+    public void disablePort(DeviceId deviceId, PortNumber portNumber) {
+        //TODO
+    }
+
     /**
      * Prepares to count device added/available/removed events.
      *


### PR DESCRIPTION
Allow enabling and disabling ports on devices using the DeviceProvider
interface by adding 2 new functions to it:

enablePort / disablePort

Those are also available in DeviceAdminService to be called from an
application to control the switches, and, its implementation, the
DeviceManager will forward the call to the DeviceProvider.

So far this is only properly implemented in the OpenFlowDeviceProvider,
all the other implementations remains as a TODO