### PR TITLE
[NC-279-1] Fix the bug that ONOS cannot associate NetConf reply with …

### DIFF
--- a/protocols/netconf/ctl/src/main/java/org/onosproject/netconf/ctl/NetconfStreamThread.java
+++ b/protocols/netconf/ctl/src/main/java/org/onosproject/netconf/ctl/NetconfStreamThread.java
@@ -221,7 +221,7 @@ public class NetconfStreamThread extends Thread implements NetconfStreamHandler 
             String[] outer = reply.split(MESSAGE_ID);
             Preconditions.checkArgument(outer.length != 1,
                                         "Error in retrieving the message id");
-            String messageID = outer[1].substring(0, 3).replace("\"", "");
+            String messageID = outer[1].split("\"")[1];
             Preconditions.checkNotNull(Integer.parseInt(messageID),
                                        "Error in retrieving the message id");
             return Optional.of(Integer.parseInt(messageID));


### PR DESCRIPTION
…its request. It appears that ONOS use `message-id` to associate reply with its request and `.string(0, 3)` will not work when `message-id` has more than three digits (>100).

@ningw, this is an upstream bug, please review my fix and merge into your `NC-279` branch.