### PR TITLE
[ONOS-4931] fix doc of FlowEntry.life(), add life(TimeUnit)

### DIFF
--- a/core/api/src/main/java/org/onosproject/net/flow/DefaultTypedFlowEntry.java
+++ b/core/api/src/main/java/org/onosproject/net/flow/DefaultTypedFlowEntry.java
@@ -16,6 +16,8 @@
 
 package org.onosproject.net.flow;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
@@ -24,6 +26,24 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class DefaultTypedFlowEntry extends DefaultFlowEntry
     implements TypedStoredFlowEntry {
     private FlowLiveType liveType;
+
+
+    /**
+     * Creates a typed flow entry from flow rule and its statistics, with default flow live type(IMMEDIATE_FLOW).
+     *
+     * @param rule the flow rule
+     * @param state the flow state
+     * @param life the flow duration since creation
+     * @param lifeTimeUnit the time unit of life
+     * @param packets the flow packets count
+     * @param bytes the flow bytes count
+     *
+     */
+    public DefaultTypedFlowEntry(FlowRule rule, FlowEntryState state,
+                                 long life, TimeUnit lifeTimeUnit, long packets, long bytes) {
+        super(rule, state, life, lifeTimeUnit, packets, bytes);
+        this.liveType = FlowLiveType.IMMEDIATE_FLOW;
+    }
 
     /**
      * Creates a typed flow entry from flow rule and its statistics, with default flow live type(IMMEDIATE_FLOW).
@@ -59,7 +79,7 @@ public class DefaultTypedFlowEntry extends DefaultFlowEntry
      *
      */
     public DefaultTypedFlowEntry(FlowEntry fe) {
-        super(fe, fe.state(), fe.life(), fe.packets(), fe.bytes());
+        super(fe, fe.state(), fe.life(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS, fe.packets(), fe.bytes());
         this.liveType = FlowLiveType.IMMEDIATE_FLOW;
     }
 
@@ -83,7 +103,7 @@ public class DefaultTypedFlowEntry extends DefaultFlowEntry
      *
      */
     public DefaultTypedFlowEntry(FlowEntry fe,  FlowLiveType liveType) {
-        super(fe, fe.state(), fe.life(), fe.packets(), fe.bytes());
+        super(fe, fe.state(), fe.life(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS, fe.packets(), fe.bytes());
         this.liveType = liveType;
     }
 

--- a/core/api/src/main/java/org/onosproject/net/flow/FlowEntry.java
+++ b/core/api/src/main/java/org/onosproject/net/flow/FlowEntry.java
@@ -16,6 +16,8 @@
 package org.onosproject.net.flow;
 
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Represents a generalized match &amp; action pair to be applied to
  * an infrastucture device.
@@ -60,11 +62,18 @@ public interface FlowEntry extends FlowRule {
     FlowEntryState state();
 
     /**
-     * Returns the number of milliseconds this flow rule has been applied.
+     * Returns the number of seconds this flow rule has been applied.
      *
-     * @return number of millis
+     * @return number of seconds
      */
     long life();
+
+    /**
+     * Returns the time this flow rule has been applied.
+     *
+     * @return time in the requested {@link TimeUnit}
+     */
+    long life(TimeUnit unit);
 
     /**
      * Returns the number of packets this flow rule has matched.

--- a/core/api/src/main/java/org/onosproject/net/flow/StoredFlowEntry.java
+++ b/core/api/src/main/java/org/onosproject/net/flow/StoredFlowEntry.java
@@ -16,6 +16,8 @@
 package org.onosproject.net.flow;
 
 
+import java.util.concurrent.TimeUnit;
+
 public interface StoredFlowEntry extends FlowEntry {
 
     /**
@@ -31,9 +33,16 @@ public interface StoredFlowEntry extends FlowEntry {
 
     /**
      * Sets how long this entry has been entered in the system.
-     * @param life epoch time
+     * @param lifeSecs seconds
      */
-    void setLife(long life);
+    void setLife(long lifeSecs);
+
+    /**
+     * Sets how long this entry has been entered in the system.
+     * @param life time
+     * @param timeUnit unit of time
+     */
+    void setLife(long life, TimeUnit timeUnit);
 
     /**
      * Number of packets seen by this entry.

--- a/core/api/src/test/java/org/onosproject/net/flow/DefaultFlowEntryTest.java
+++ b/core/api/src/test/java/org/onosproject/net/flow/DefaultFlowEntryTest.java
@@ -75,6 +75,9 @@ public class DefaultFlowEntryTest {
         assertThat(defaultFlowEntry1.treatment(), is(TREATMENT));
         assertThat(defaultFlowEntry1.timeout(), is(1));
         assertThat(defaultFlowEntry1.life(), is(1L));
+        assertThat(defaultFlowEntry1.life(TimeUnit.SECONDS), is(1L));
+        assertThat(defaultFlowEntry1.life(TimeUnit.MILLISECONDS), is(1000L));
+        assertThat(defaultFlowEntry1.life(TimeUnit.MINUTES), is(0L));
         assertThat(defaultFlowEntry1.packets(), is(1L));
         assertThat(defaultFlowEntry1.bytes(), is(1L));
         assertThat(defaultFlowEntry1.state(), is(FlowEntry.FlowEntryState.ADDED));
@@ -94,13 +97,14 @@ public class DefaultFlowEntryTest {
         entry.setState(FlowEntry.FlowEntryState.PENDING_REMOVE);
         entry.setPackets(11);
         entry.setBytes(22);
-        entry.setLife(33);
+        entry.setLife(33333, TimeUnit.MILLISECONDS);
 
         assertThat(entry.deviceId(), is(did("id1")));
         assertThat(entry.selector(), is(SELECTOR));
         assertThat(entry.treatment(), is(TREATMENT));
         assertThat(entry.timeout(), is(1));
         assertThat(entry.life(), is(33L));
+        assertThat(entry.life(TimeUnit.MILLISECONDS), is(33333L));
         assertThat(entry.packets(), is(11L));
         assertThat(entry.bytes(), is(22L));
         assertThat(entry.state(), is(FlowEntry.FlowEntryState.PENDING_REMOVE));

--- a/core/common/src/main/java/org/onosproject/codec/impl/FlowEntryCodec.java
+++ b/core/common/src/main/java/org/onosproject/codec/impl/FlowEntryCodec.java
@@ -51,7 +51,7 @@ public final class FlowEntryCodec extends JsonCodec<FlowEntry> {
                 .put("isPermanent", flowEntry.isPermanent())
                 .put("deviceId", flowEntry.deviceId().toString())
                 .put("state", flowEntry.state().toString())
-                .put("life", flowEntry.life())
+                .put("life", flowEntry.life()) //FIXME life is destroying precision (seconds granularity is default)
                 .put("packets", flowEntry.packets())
                 .put("bytes", flowEntry.bytes())
                 .put("lastSeen", flowEntry.lastSeen());

--- a/core/store/dist/src/main/java/org/onosproject/store/flow/impl/DistributedFlowRuleStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/flow/impl/DistributedFlowRuleStore.java
@@ -555,7 +555,7 @@ public class DistributedFlowRuleStore
         if (stored != null) {
             //FIXME modification of "stored" flow entry outside of flow table
             stored.setBytes(rule.bytes());
-            stored.setLife(rule.life());
+            stored.setLife(rule.life(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
             stored.setPackets(rule.packets());
             stored.setLastSeen();
             if (stored.state() == FlowEntryState.PENDING_ADD) {

--- a/providers/openflow/flow/src/main/java/org/onosproject/provider/of/flow/impl/NewAdaptiveFlowStatsCollector.java
+++ b/providers/openflow/flow/src/main/java/org/onosproject/provider/of/flow/impl/NewAdaptiveFlowStatsCollector.java
@@ -449,7 +449,7 @@ public class NewAdaptiveFlowStatsCollector implements SwitchDataCollector {
 
                 // update now
                 //FIXME modification of "stored" flow entry outside of store
-                stored.setLife(fe.life());
+                stored.setLife(fe.life(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
                 stored.setPackets(fe.packets());
                 stored.setBytes(fe.bytes());
                 stored.setLastSeen();

--- a/providers/openflow/flow/src/main/java/org/onosproject/provider/of/flow/util/FlowEntryBuilder.java
+++ b/providers/openflow/flow/src/main/java/org/onosproject/provider/of/flow/util/FlowEntryBuilder.java
@@ -93,6 +93,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.onosproject.net.flow.criteria.Criteria.*;
 import static org.onosproject.net.flow.instructions.Instructions.modL0Lambda;
@@ -170,7 +171,9 @@ public class FlowEntryBuilder {
                     }
 
                     return new DefaultFlowEntry(builder.build(), FlowEntryState.ADDED,
-                                                stat.getDurationSec(),
+                                                TimeUnit.SECONDS.toNanos(stat.getDurationSec())
+                                                        + stat.getDurationNsec(),
+                                                TimeUnit.NANOSECONDS,
                                                 stat.getPacketCount().getValue(),
                                                 stat.getByteCount().getValue());
                 case REMOVED:
@@ -185,7 +188,9 @@ public class FlowEntryBuilder {
                     }
 
                     return new DefaultFlowEntry(builder.build(), FlowEntryState.REMOVED,
-                                                removed.getDurationSec(),
+                                                TimeUnit.SECONDS.toNanos(removed.getDurationSec())
+                                                        + removed.getDurationNsec(),
+                                                TimeUnit.NANOSECONDS,
                                                 removed.getPacketCount().getValue(),
                                                 removed.getByteCount().getValue());
                 case MOD:

--- a/web/api/src/test/java/org/onosproject/rest/resources/FlowsResourceTest.java
+++ b/web/api/src/test/java/org/onosproject/rest/resources/FlowsResourceTest.java
@@ -64,6 +64,7 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyShort;
@@ -141,7 +142,12 @@ public class FlowsResourceTest extends ResourceTest {
 
         @Override
         public long life() {
-            return baseValue + 11;
+            return life(TimeUnit.SECONDS);
+        }
+
+        @Override
+        public long life(TimeUnit timeUnit) {
+            return TimeUnit.SECONDS.convert(baseValue + 11, timeUnit);
         }
 
         @Override


### PR DESCRIPTION
Fix the doc: life() returns the time in seconds, not milliseconds.

Add new method life(TimeUnit) that allows specifying the timeunit to
receive the life value as as seconds might not be enough for
all applications and OpenFlow can provide this value to nanoseconds resolution
(in its spec).

Change-Id: Ia6a7573797249e0edc04e03c7204a550a2823742