### PR TITLE
OpenFlowControllerImpl: always cleanup on deactivate

### DIFF
--- a/protocols/openflow/ctl/src/main/java/org/onosproject/openflow/controller/impl/OpenFlowControllerImpl.java
+++ b/protocols/openflow/ctl/src/main/java/org/onosproject/openflow/controller/impl/OpenFlowControllerImpl.java
@@ -174,9 +174,7 @@ public class OpenFlowControllerImpl implements OpenFlowController {
 
     @Deactivate
     public void deactivate() {
-        if (!connectedSwitches.isEmpty()) {
-            cleanup();
-        }
+        cleanup();
         cfgService.unregisterProperties(getClass(), false);
     }
 


### PR DESCRIPTION
Even if we don't have devices, the sockets/channels must be closed.

This is particularly harmful when onos is restarted to form a cluster
and the openflow channels are left open. On the next
activation it will try to open ports that were already open and it
fails

Change-Id: I768b9db0b71ffba2805fabf631adcb2039af89e4