### PR TITLE
Change KARAF_VERSION to 3.0.5 to follow upstream

### DIFF
--- a/features/features.xml
+++ b/features/features.xml
@@ -16,7 +16,7 @@
   -->
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
           name="onos-@FEATURE-VERSION">
-    <repository>mvn:org.apache.karaf.features/standard/3.0.6/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/standard/3.0.5/xml/features</repository>
 
     <feature name="onos-thirdparty-base" version="@FEATURE-VERSION"
              description="ONOS 3rd party dependencies">

--- a/lib/deps.json
+++ b/lib/deps.json
@@ -178,7 +178,7 @@
     "typesafe-config": "mvn:com.typesafe:config:1.2.1",
     "validation-api": "mvn:javax.validation:validation-api:1.1.0.Final",
     "checkstyle": "mvn:com.puppycrawl.tools:checkstyle:6.11.2",
-    "apache-karaf": "http://onlab.vicci.org/onos/third-party/apache-karaf-3.0.5.tar.gz",
+    "apache-karaf": "http://archive.apache.org/dist/karaf/3.0.5/apache-karaf-3.0.5.tar.gz",
     "bndlib": "mvn:biz.aQute.bnd:biz.aQute.bndlib:jar:3.1.0",
     "org.apache.felix.scr.bnd": {
       "uri": "mvn:org.onosproject:org.apache.felix.scr.bnd:1.4.1-SNAPSHOT",

--- a/tools/build/envDefaults
+++ b/tools/build/envDefaults
@@ -5,7 +5,7 @@ export ONOS_ROOT=${ONOS_ROOT:-~/onos}
 
 # M2 repository and Karaf gold bits
 export M2_REPO=${M2_REPO:-~/.m2/repository}
-export KARAF_VERSION=${KARAF_VERSION:-3.0.6}
+export KARAF_VERSION=${KARAF_VERSION:-3.0.5}
 export KARAF_ZIP=${KARAF_ZIP:-~/Downloads/apache-karaf-$KARAF_VERSION.zip}
 export KARAF_TAR=${KARAF_TAR:-~/Downloads/apache-karaf-$KARAF_VERSION.tar.gz}
 export KARAF_DIST=$(basename $KARAF_ZIP .zip)

--- a/tools/build/onos-package
+++ b/tools/build/onos-package
@@ -18,7 +18,7 @@ function build_stage_dir() {
     # Check if Apache Karaf bits are available and if not, fetch them.
     if [ ! -f $KARAF_ZIP -a ! -f $KARAF_TAR ]; then
         echo "Downloading $KARAF_TAR..."
-        curl -sL http://downloads.onosproject.org/third-party/apache-karaf-$KARAF_VERSION.tar.gz > $KARAF_TAR
+        curl -SL http://archive.apache.org/dist/karaf/$KARAF_VERSION/apache-karaf-$KARAF_VERSION.tar.gz > $KARAF_TAR
     fi
     [ ! -f $KARAF_ZIP -a ! -f $KARAF_TAR ] && \
         echo "Apache Karaf bits $KARAF_ZIP or $KARAF_TAR not found" && exit 1

--- a/tools/dev/bash_profile
+++ b/tools/dev/bash_profile
@@ -18,7 +18,7 @@ fi
 
 export MAVEN=${MAVEN:-~/Applications/apache-maven-3.3.9}
 
-export KARAF_VERSION=${KARAF_VERSION:-3.0.6}
+export KARAF_VERSION=${KARAF_VERSION:-3.0.5}
 export KARAF_ROOT=${KARAF_ROOT:-~/Applications/apache-karaf-$KARAF_VERSION}
 export KARAF_LOG=$KARAF_ROOT/data/log/karaf.log
 

--- a/tools/dev/bin/onos-setup-ubuntu-devenv
+++ b/tools/dev/bin/onos-setup-ubuntu-devenv
@@ -14,8 +14,8 @@ export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 
 cd; mkdir Downloads Applications
 cd Downloads
-wget http://download.nextag.com/apache/karaf/3.0.6/apache-karaf-3.0.6.tar.gz
+wget http://archive.apache.org/dist/karaf/3.0.5/apache-karaf-3.0.5.tar.gz
 wget http://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-tar -zxvf apache-karaf-3.0.6.tar.gz -C ../Applications/
+tar -zxvf apache-karaf-3.0.5.tar.gz -C ../Applications/
 tar -zxvf apache-maven-3.3.9-bin.tar.gz -C ../Applications/
 

--- a/tools/dev/onos.cshrc
+++ b/tools/dev/onos.cshrc
@@ -27,7 +27,7 @@ if ( ! $?MAVEN ) then
     setenv MAVEN $HOME/Applications/apache-maven-3.3.9
 endif
 if ( ! $?KARAF_VERSION ) then
-    setenv KARAF_VERSION 3.0.6
+    setenv KARAF_VERSION 3.0.5
 endif
 if ( ! $?KARAF_ROOT ) then
     setenv KARAF_ROOT $HOME/Applications/apache-karaf-$KARAF_VERSION

--- a/tools/package/deb/prerm
+++ b/tools/package/deb/prerm
@@ -14,7 +14,7 @@
 
 # Clean up onos runtime directories
 #      TODO don't hardcode karaf version
-rm -rf /opt/onos/apache-karaf-3.0.6/
+rm -rf /opt/onos/apache-karaf-3.0.5/
 rm -rf /opt/onos/var/*
 rm -rf /opt/onos/config
 rm -rf /opt/onos/options

--- a/tools/package/init/onos.conf
+++ b/tools/package/init/onos.conf
@@ -21,7 +21,7 @@ pre-start script
     [ -d /opt/onos ] && mkdir /opt/onos/config 2>/dev/null && chown $ONOS_USER.$ONOS_USER /opt/onos/config
     # TODO make karaf version configurable
     [ -d /opt/onos ] && [ ! -h /opt/onos/log ] \
-         && ln -s /opt/onos/apache-karaf-3.0.6/data/log /opt/onos/log || :
+         && ln -s /opt/onos/apache-karaf-3.0.5/data/log /opt/onos/log || :
 end script
 
 pre-stop script

--- a/tools/package/karaf-assembly/pom.xml
+++ b/tools/package/karaf-assembly/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>3.0.6</version>
+                <version>3.0.5</version>
 
                 <executions>
                     <execution>

--- a/tools/test/topos/onos.py
+++ b/tools/test/topos/onos.py
@@ -36,7 +36,7 @@ class ONOS( Controller ):
         #self.checkListening()
 
         self.onosDir = onosDir
-        self.karafDir = onosDir + 'apache-karaf-3.0.6/'
+        self.karafDir = onosDir + 'apache-karaf-3.0.5/'
         self.instanceDir = self.karafDir
 
         # add default modules


### PR DESCRIPTION
Upstream ONOS stopped at Karaf version 3.0.5 and there are a few compatibility issues with the docker setup that were uncovered by the update (and hadn't been noticed before) - the Karaf executable was changed and it no longer picks up the PATH and CLASSPATH correctly. While it might be worthwhile to update Karaf at some point, I don't believe there is a lot of sense into us making changes to Karaf itself right now - I suggest that we just follow upstream.