### PR TITLE
[ONOS-5156] DistributedGroupStore: keep both entries map in sync

### DIFF
--- a/core/store/dist/src/main/java/org/onosproject/store/group/impl/DistributedGroupStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/group/impl/DistributedGroupStore.java
@@ -201,6 +201,7 @@ public class DistributedGroupStore
         groupStoreEntriesByKey.addListener(new GroupStoreKeyMapListener());
         log.debug("Current size of groupstorekeymap:{}",
                   groupStoreEntriesByKey.size());
+        synchronizeGroupStoreEntries();
 
         log.debug("Creating Consistent map pendinggroupkeymap");
 
@@ -245,6 +246,18 @@ public class DistributedGroupStore
     private static NewConcurrentHashMap<GroupId, StoredGroupEntry>
     lazyEmptyGroupIdTable() {
         return NewConcurrentHashMap.<GroupId, StoredGroupEntry>ifNeeded();
+    }
+
+
+    private void synchronizeGroupStoreEntries() {
+        Map<GroupStoreKeyMapKey, StoredGroupEntry> groupEntryMap = groupStoreEntriesByKey.asJavaMap();
+        for (Entry<GroupStoreKeyMapKey, StoredGroupEntry> entry : groupEntryMap.entrySet()) {
+            GroupStoreKeyMapKey key = entry.getKey();
+            StoredGroupEntry value = entry.getValue();
+
+            ConcurrentMap<GroupId, StoredGroupEntry> groupIdTable = getGroupIdTable(value.deviceId());
+            groupIdTable.put(value.id(), value);
+        }
     }
 
     /**


### PR DESCRIPTION
There are 2 maps to store groupstores, keep both in sync from the start.
It can happen that the deviceid-based map isn't properly initialized
when the store gets data from other peers in a cluster in activate()

Change-Id: Ia33929f734a846c72890cf57095ea9ff8d2d394c

