### PR TITLE
DistributedGroupStore: decrease logging level of "unchanged buckets"

### DIFF
--- a/core/store/dist/src/main/java/org/onosproject/store/group/impl/DistributedGroupStore.java
+++ b/core/store/dist/src/main/java/org/onosproject/store/group/impl/DistributedGroupStore.java
@@ -723,7 +723,7 @@ public class DistributedGroupStore
                                                 newGroup.appCookie()), newGroup);
             notifyDelegate(new GroupEvent(Type.GROUP_UPDATE_REQUESTED, newGroup));
         } else {
-            log.warn("updateGroupDescriptionInternal with type {}: No "
+            log.debug("updateGroupDescriptionInternal with type {}: No "
                              + "change in the buckets in update", type);
         }
     }


### PR DESCRIPTION
Buckets not having changed in an update can be an extremely
common event - it'll happen whenever the weights of buckets
for a given group doesn't change.

Change logging level from WARN to DEBUG to avoid cluttering
logs.
