### PR TITLE
Enable source ip and in-port criteria in OVSAdvanced

### DIFF
--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -457,11 +457,22 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
                 DefaultTrafficSelector.builder();
         int forTableId = -1;
         if (ethType.ethType().toShort() == Ethernet.TYPE_IPV4) {
+            IPCriterion destinationCriterion = (IPCriterion) selector.getCriterion(Criterion.Type.IPV4_DST);
+            IPCriterion sourceCriterion = (IPCriterion) selector.getCriterion(Criterion.Type.IPV4_SRC);
+            PortCriterion inPortCriterion = (PortCriterion) selector.getCriterion(Criterion.Type.IN_PORT);
+
             filteredSelectorBuilder = filteredSelectorBuilder
                 .matchEthType(Ethernet.TYPE_IPV4)
-                .matchIPDst(((IPCriterion) selector
-                        .getCriterion(Criterion.Type.IPV4_DST))
-                        .ip());
+                .matchIPDst(destinationCriterion.ip());
+
+            if (sourceCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPSrc(sourceCriterion.ip());
+            }
+
+            if (inPortCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchInPort(inPortCriterion.port());
+            }
+
             forTableId = ipv4UnicastTableId;
             log.debug("processing IPv4 specific forwarding objective");
         } else {


### PR DESCRIPTION
Goes with https://github.com/waltznetworks/onos-app/pull/116, in which we add source IP and in port criteria to our traffic selectors.

@ningw @victorssilva @thiagoss 