### PR TITLE
Switch port stats poll frequency units to milliseconds

### DIFF
--- a/providers/openflow/device/src/main/java/org/onosproject/provider/of/device/impl/OpenFlowDeviceProvider.java
+++ b/providers/openflow/device/src/main/java/org/onosproject/provider/of/device/impl/OpenFlowDeviceProvider.java
@@ -149,9 +149,9 @@ public class OpenFlowDeviceProvider extends AbstractProvider implements DevicePr
 
     private final InternalDeviceProvider listener = new InternalDeviceProvider();
 
-    static final int POLL_INTERVAL = 5;
+    static final int POLL_INTERVAL = 5000;
     @Property(name = "PortStatsPollFrequency", intValue = POLL_INTERVAL,
-    label = "Frequency (in seconds) for polling switch Port statistics")
+    label = "Frequency (in milli-seconds) for polling switch Port statistics")
     private int portStatsPollFrequency = POLL_INTERVAL;
 
     private HashMap<Dpid, PortStatsCollector> collectors = Maps.newHashMap();

--- a/providers/openflow/device/src/main/java/org/onosproject/provider/of/device/impl/PortStatsCollector.java
+++ b/providers/openflow/device/src/main/java/org/onosproject/provider/of/device/impl/PortStatsCollector.java
@@ -70,7 +70,7 @@ public class PortStatsCollector implements TimerTask {
         if (!stopped && !timeout.isCancelled()) {
             log.trace("Scheduling stats collection in {} seconds for {}",
                     this.refreshInterval, this.sw.getStringId());
-            timeout.getTimer().newTimeout(this, refreshInterval, TimeUnit.SECONDS);
+            timeout.getTimer().newTimeout(this, refreshInterval, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -102,7 +102,7 @@ public class PortStatsCollector implements TimerTask {
     public synchronized void start() {
         log.info("Starting Port Stats collection thread for {}", sw.getStringId());
         stopped = false;
-        timeout = timer.newTimeout(this, 1, TimeUnit.SECONDS);
+        timeout = timer.newTimeout(this, 1000, TimeUnit.MILLISECONDS);
     }
 
     /**


### PR DESCRIPTION
We may want to the flexibility to set port stats poll frequency below 1 second, if the devices we are working with support it.

@victorssilva @thiagoss 