### PR TITLE
yangutils: change onlab-junit dependency to 1.7.0

### DIFF
--- a/utils/yangutils/plugin/pom.xml
+++ b/utils/yangutils/plugin/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.onosproject</groupId>
             <artifactId>onlab-junit</artifactId>
-            <version>1.7.0-SNAPSHOT</version>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
1.7.0-SNAPSHOT is no longer available on public repositories.

Change-Id: Iedf7526e344d5ca65e0cdf14a57408817d599a8b