### PR TITLE
OVSAdvanced driver: UDP/TCT Port matching

### DIFF
--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -51,6 +51,7 @@ import org.onosproject.net.flow.criteria.EthTypeCriterion;
 import org.onosproject.net.flow.criteria.IPCriterion;
 import org.onosproject.net.flow.criteria.MplsCriterion;
 import org.onosproject.net.flow.criteria.PortCriterion;
+import org.onosproject.net.flow.criteria.UdpPortCriterion;
 import org.onosproject.net.flow.criteria.VlanIdCriterion;
 import org.onosproject.net.flow.instructions.Instruction;
 import org.onosproject.net.flowobjective.FilteringObjective;
@@ -460,10 +461,10 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
             IPCriterion destinationCriterion = (IPCriterion) selector.getCriterion(Criterion.Type.IPV4_DST);
             IPCriterion sourceCriterion = (IPCriterion) selector.getCriterion(Criterion.Type.IPV4_SRC);
             PortCriterion inPortCriterion = (PortCriterion) selector.getCriterion(Criterion.Type.IN_PORT);
+            UdpPortCriterion udpSrcPortCriterion = (UdpPortCriterion) selector.getCriterion(Criterion.Type.UDP_SRC);
+            UdpPortCriterion udpDstPortCriterion = (UdpPortCriterion) selector.getCriterion(Criterion.Type.UDP_DST);
 
-            filteredSelectorBuilder = filteredSelectorBuilder
-                .matchEthType(Ethernet.TYPE_IPV4)
-                .matchIPDst(destinationCriterion.ip());
+            filteredSelectorBuilder = filteredSelectorBuilder.matchEthType(Ethernet.TYPE_IPV4);
 
             if (sourceCriterion != null) {
                 filteredSelectorBuilder = filteredSelectorBuilder.matchIPSrc(sourceCriterion.ip());
@@ -473,7 +474,20 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
                 filteredSelectorBuilder = filteredSelectorBuilder.matchInPort(inPortCriterion.port());
             }
 
+            if (destinationCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPDst(destinationCriterion.ip());
+            }
+
+            if (udpSrcPortCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchUdpSrc(udpSrcPortCriterion.udpPort());
+            }
+
+            if (udpDstPortCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchUdpDst(udpDstPortCriterion.udpPort());
+            }
+
             forTableId = ipv4UnicastTableId;
+
             log.debug("processing IPv4 specific forwarding objective");
         } else {
             filteredSelectorBuilder = filteredSelectorBuilder

--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -418,8 +418,8 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
                 treatmentBuilder.deferred().group(group.id());
                 log.debug("Adding OUTGROUP action");
             }
-        } else {
-            log.warn("VERSATILE forwarding objective need next objective ID.");
+        } else if (fwd.treatment() == null) {
+            log.warn("VERSATILE forwarding objective need next objective ID or treatment.");
             return Collections.emptySet();
         }
 

--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -25,6 +25,7 @@ import com.google.common.cache.RemovalNotification;
 
 import org.onlab.osgi.ServiceDirectory;
 import org.onlab.packet.Ethernet;
+import org.onlab.packet.IPv4;
 import org.onlab.packet.VlanId;
 import org.onlab.util.KryoNamespace;
 import org.onosproject.core.ApplicationId;
@@ -485,19 +486,23 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
             }
 
             if (udpSrcPortCriterion != null) {
-                filteredSelectorBuilder = filteredSelectorBuilder.matchUdpSrc(udpSrcPortCriterion.udpPort());
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPProtocol(IPv4.PROTOCOL_UDP)
+                        .matchUdpSrc(udpSrcPortCriterion.udpPort());
             }
 
             if (udpDstPortCriterion != null) {
-                filteredSelectorBuilder = filteredSelectorBuilder.matchUdpDst(udpDstPortCriterion.udpPort());
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPProtocol(IPv4.PROTOCOL_UDP)
+                        .matchUdpDst(udpDstPortCriterion.udpPort());
             }
 
             if (tcpSrcPortCriterion != null) {
-                filteredSelectorBuilder = filteredSelectorBuilder.matchTcpSrc(tcpSrcPortCriterion.tcpPort());
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPProtocol(IPv4.PROTOCOL_TCP)
+                        .matchTcpSrc(tcpSrcPortCriterion.tcpPort());
             }
 
             if (tcpDstPortCriterion != null) {
-                filteredSelectorBuilder = filteredSelectorBuilder.matchTcpDst(tcpDstPortCriterion.tcpPort());
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPProtocol(IPv4.PROTOCOL_TCP)
+                        .matchTcpDst(tcpDstPortCriterion.tcpPort());
             }
 
             if (ipProtocolCriterion != null) {

--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -49,8 +49,10 @@ import org.onosproject.net.flow.criteria.Criterion;
 import org.onosproject.net.flow.criteria.EthCriterion;
 import org.onosproject.net.flow.criteria.EthTypeCriterion;
 import org.onosproject.net.flow.criteria.IPCriterion;
+import org.onosproject.net.flow.criteria.IPProtocolCriterion;
 import org.onosproject.net.flow.criteria.MplsCriterion;
 import org.onosproject.net.flow.criteria.PortCriterion;
+import org.onosproject.net.flow.criteria.TcpPortCriterion;
 import org.onosproject.net.flow.criteria.UdpPortCriterion;
 import org.onosproject.net.flow.criteria.VlanIdCriterion;
 import org.onosproject.net.flow.instructions.Instruction;
@@ -463,6 +465,10 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
             PortCriterion inPortCriterion = (PortCriterion) selector.getCriterion(Criterion.Type.IN_PORT);
             UdpPortCriterion udpSrcPortCriterion = (UdpPortCriterion) selector.getCriterion(Criterion.Type.UDP_SRC);
             UdpPortCriterion udpDstPortCriterion = (UdpPortCriterion) selector.getCriterion(Criterion.Type.UDP_DST);
+            TcpPortCriterion tcpSrcPortCriterion = (TcpPortCriterion) selector.getCriterion(Criterion.Type.TCP_SRC);
+            TcpPortCriterion tcpDstPortCriterion = (TcpPortCriterion) selector.getCriterion(Criterion.Type.TCP_DST);
+            IPProtocolCriterion ipProtocolCriterion = (IPProtocolCriterion) selector.getCriterion(
+                    Criterion.Type.IP_PROTO);
 
             filteredSelectorBuilder = filteredSelectorBuilder.matchEthType(Ethernet.TYPE_IPV4);
 
@@ -484,6 +490,19 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
 
             if (udpDstPortCriterion != null) {
                 filteredSelectorBuilder = filteredSelectorBuilder.matchUdpDst(udpDstPortCriterion.udpPort());
+            }
+
+            if (tcpSrcPortCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchTcpSrc(tcpSrcPortCriterion.tcpPort());
+            }
+
+            if (tcpDstPortCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchTcpDst(tcpDstPortCriterion.tcpPort());
+            }
+
+            if (ipProtocolCriterion != null) {
+                filteredSelectorBuilder = filteredSelectorBuilder.matchIPProtocol(
+                        Integer.valueOf(ipProtocolCriterion.protocol()).byteValue());
             }
 
             forTableId = ipv4UnicastTableId;

--- a/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
+++ b/drivers/default/src/main/java/org/onosproject/driver/pipeline/OVSAdvanced.java
@@ -405,6 +405,7 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
         TrafficTreatment.Builder treatmentBuilder = DefaultTrafficTreatment
                 .builder();
         treatmentBuilder.wipeDeferred();
+        TrafficTreatment treatment = null;
 
         if (fwd.nextId() != null) {
             NextGroup next = flowObjectiveStore.getNextGroup(fwd.nextId());
@@ -422,12 +423,13 @@ public class OVSAdvanced extends AbstractHandlerBehaviour
                 treatmentBuilder.deferred().group(group.id());
                 log.debug("Adding OUTGROUP action");
             }
+            treatment = treatmentBuilder.build();
         } else if (fwd.treatment() == null) {
             log.warn("VERSATILE forwarding objective need next objective ID or treatment.");
             return Collections.emptySet();
+        } else {
+            treatment = fwd.treatment();
         }
-
-        TrafficTreatment treatment = treatmentBuilder.build();
 
         FlowRule.Builder ruleBuilder = DefaultFlowRule.builder()
                 .fromApp(fwd.appId()).withPriority(fwd.priority())


### PR DESCRIPTION
Improves our OVS driver to be able to accept UDP and TCP port matching.

Also makes it capable of handling 'deny' rules and fixes a bug on handling treatment from ObjectiveForward