### PR TITLE
NC-544: Implementation of link discovery

### DIFF
--- a/core/api/src/main/java/org/onosproject/net/AnnotationKeys.java
+++ b/core/api/src/main/java/org/onosproject/net/AnnotationKeys.java
@@ -105,6 +105,11 @@ public final class AnnotationKeys {
     public static final String PORT_IP = "portIp";
 
     /**
+     * Annotation key for the port VLAN ID.
+     */
+    public static final String PORT_VLAN_ID = "portVlanId";
+
+    /**
      * Annotation key for the router ID.
      */
     public static final String ROUTER_ID = "routerId";

--- a/core/api/src/main/java/org/onosproject/net/AnnotationKeys.java
+++ b/core/api/src/main/java/org/onosproject/net/AnnotationKeys.java
@@ -100,6 +100,11 @@ public final class AnnotationKeys {
     public static final String PORT_MAC = "portMac";
 
     /**
+     * Annotation key for the port IP address.
+     */
+    public static final String PORT_IP = "portIp";
+
+    /**
      * Annotation key for the router ID.
      */
     public static final String ROUTER_ID = "routerId";

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -146,7 +146,16 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
         DeviceService deviceService = checkNotNull(handler().get(DeviceService.class));
         DeviceId deviceId;
 
+        /* The remote device could be an OpenFlow device, an SNMP devices, or a NETCONF device. In ONOS,
+         * these devices will have different URI prefix. For example, an OpenFlow device will have 'of' prefix
+         * and no port number; an SNMP device, similarly, will have 'snmp' prefix; a NETCONF device will have
+         * 'netconf' prefix and so on. This method should serve as a DeviceId resolver. That is, given an IP,
+         * try to look for the device in ONOS and return its DeviceId.
+         */
         try {
+            /* Test if the remote device is a NETCONF device. NETCONF protocol runs on either port 22 on Cisco
+             * routers through SSHv2 tunnels or port 830 on Juniper routers through non-encrypted tunnels.
+             */
             deviceId = DeviceId.deviceId(new URI("netconf", ip + ":" + 22, null));      // check if port is 22
             if (deviceService.getDevice(deviceId) != null) {
                 return deviceId;

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -1,0 +1,27 @@
+package org.onosproject.drivers.cisco;
+
+import org.onosproject.net.behaviour.LinkDiscovery;
+import org.onosproject.net.driver.AbstractHandlerBehaviour;
+import org.onosproject.net.link.LinkDescription;
+import org.slf4j.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Retrieve link descriptions from Cisco CSR1000v router through OSPF hello messages via netconf.
+ */
+public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
+        implements LinkDiscovery {
+
+    private final Logger log = getLogger(getClass());
+
+    @Override
+    public Set<LinkDescription> getLinks() {
+        Set<LinkDescription> links = new HashSet<>();
+
+        return links;
+    }
+}

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -36,6 +36,8 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
         implements LinkDiscovery {
 
     private final Logger log = getLogger(getClass());
+    private static final int SSH_PORT = 22;
+    private static final int NETCONF_PORT = 830;
 
     @Override
     public Set<LinkDescription> getLinks() {
@@ -170,11 +172,11 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
             /* Test if the remote device is a NETCONF device. NETCONF protocol runs on either port 22 on Cisco
              * routers through SSHv2 tunnels or port 830 on Juniper routers through non-encrypted tunnels.
              */
-            deviceId = DeviceId.deviceId(new URI("netconf", ip + ":" + 22, null));      // check if port is 22
+            deviceId = DeviceId.deviceId(new URI("netconf", ip + ":" + SSH_PORT, null));      // check if port is 22
             if (deviceService.getDevice(deviceId) != null) {
                 return deviceId;
             }
-            deviceId = DeviceId.deviceId(new URI("netconf", ip + ":" + 830, null));     // check if port is 830
+            deviceId = DeviceId.deviceId(new URI("netconf", ip + ":" + NETCONF_PORT, null));     // check if port is 830
             if (deviceService.getDevice(deviceId) != null) {
                 return deviceId;
             }

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -2,8 +2,13 @@ package org.onosproject.drivers.cisco;
 
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.onosproject.drivers.utilities.XmlConfigParser;
+import org.onosproject.net.ConnectPoint;
+import org.onosproject.net.DeviceId;
+import org.onosproject.net.Link;
+import org.onosproject.net.PortNumber;
 import org.onosproject.net.behaviour.LinkDiscovery;
 import org.onosproject.net.driver.AbstractHandlerBehaviour;
+import org.onosproject.net.link.DefaultLinkDescription;
 import org.onosproject.net.link.LinkDescription;
 import org.onosproject.netconf.NetconfController;
 import org.onosproject.netconf.NetconfException;
@@ -80,9 +85,46 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
      */
     private Set<LinkDescription> parseCsr1000vOspfLinks(HierarchicalConfiguration cfg) {
         Set<LinkDescription> links = new HashSet<>();
+        DeviceId localDevice = handler().data().deviceId();
+        DeviceId remoteDevice;
+        PortNumber localPortNumber;
+        PortNumber remotePortNumber;
+        ConnectPoint local;
+        ConnectPoint remote;
+
         List<Object> ospfLinkInfo = cfg.getList("data.cli-oper-data-block.item.response");
+        String[] array;
         for (int i = 0; i < ospfLinkInfo.size(); i++) {
             log.info("OSPF neighbor: {}", ospfLinkInfo.get(i).toString());
+            /* Example string:
+             *   192.168.0.3       1   DOWN            00:00:00    10.100.2.3      GigabitEthernet3
+             *   192.168.0.4       1   FULL/DR         00:00:31    10.100.4.4      GigabitEthernet4
+             *
+             * The first column is the router ID, which Cisco by default use the addresses set on GigabitEthernet1;
+             * the second column is the priority and we don't use it for link discovery; the third one is the status
+             * of the link. As long as it contains "FULL", we can safely assume there is bi-directional full-speed
+             * link; the fourth columns is the IP address set on the interface on the neighbor, we will need to use
+             * this to find out port number later; the fifth column is the local interface of the link and we should
+             * convert it to local port number. Refer to:
+             * http://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13688-16.html
+             * for more detail.
+             */
+            array = ospfLinkInfo.get(i).toString().split(" +");                 // split with multiple spaces
+            if (!array[2].contains("FULL") || array.length != 6) {
+                continue;   // skip if there is no bi-directional link
+            }
+
+            remoteDevice = DeviceId.deviceId("netconf:" + array[0] + ":22");    // Cisco devices use SSHv2 (port 22)
+            // Fixme: this works for devices connected through NETCONF on port 22 and we should find a better solution
+            remotePortNumber = PortNumber.ANY;                                  // Mark ANY here
+
+
+            localPortNumber = PortNumber.portNumber(Long.parseLong(array[5].replace("GigabitEthernet", "")));
+
+            local = new ConnectPoint(localDevice, localPortNumber);
+            remote = new ConnectPoint(remoteDevice, remotePortNumber);
+
+            links.add(new DefaultLinkDescription(local, remote, Link.Type.DIRECT, true));
         }
 
         return links;

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -1,13 +1,21 @@
 package org.onosproject.drivers.cisco;
 
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.onosproject.drivers.utilities.XmlConfigParser;
 import org.onosproject.net.behaviour.LinkDiscovery;
 import org.onosproject.net.driver.AbstractHandlerBehaviour;
 import org.onosproject.net.link.LinkDescription;
+import org.onosproject.netconf.NetconfController;
+import org.onosproject.netconf.NetconfException;
+import org.onosproject.netconf.NetconfSession;
 import org.slf4j.Logger;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -20,6 +28,56 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
 
     @Override
     public Set<LinkDescription> getLinks() {
+        NetconfController controller = checkNotNull(handler().get(NetconfController.class));
+        NetconfSession session = controller.getDevicesMap().get(handler().data().deviceId()).getSession();
+        String reply;
+        try {
+            reply = session.get(getOspfLinksRequestBuilder());
+            log.debug("Device {} replies {}", handler().data().deviceId(), reply.replaceAll("\r", ""));
+        } catch (IOException e) {
+            throw new RuntimeException(new NetconfException("Failed to retrieve configuration.", e));
+        }
+
+        Set<LinkDescription> links =
+                parseCsr1000vOspfLinks(XmlConfigParser.loadXml(new ByteArrayInputStream(reply.getBytes())));
+
+        return links;
+    }
+
+    /**
+     * Builds a request crafted to get the configuration required to create link
+     * descriptions for the device.
+     * @return The request string.
+     */
+    private String getOspfLinksRequestBuilder() {
+        StringBuilder rpc = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        //Message ID is injected later.
+        rpc.append("<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">");
+        rpc.append("<get>");
+        rpc.append("<filter>");
+        rpc.append("<config-format-text-cmd>");
+        /* Use regular expression to extract only name of the interfaces from running-config */
+        rpc.append("<text-filter-spec> | include interface </text-filter-spec>");
+        rpc.append("</config-format-text-cmd>");
+        rpc.append("<oper-data-format-text-block>");
+        /* Use regular expression to extract status of the interfaces
+         * Note that there is an space after 'packet'
+         */
+        rpc.append("<exec>show ip ospf neighbor | include Ethernet</exec>");
+        rpc.append("</oper-data-format-text-block>");
+        rpc.append("</filter>");
+        rpc.append("</get>");
+        rpc.append("</rpc>");
+
+        return rpc.toString();
+    }
+
+    /**
+     * Parses a configuration and returns a set of link descriptions for Cisco CSR1000v.
+     * @param cfg a hierarchical configuration but might not in pure XML format
+     * @return a set of link descriptions
+     */
+    private Set<LinkDescription> parseCsr1000vOspfLinks(HierarchicalConfiguration cfg) {
         Set<LinkDescription> links = new HashSet<>();
 
         return links;

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/LinkDiscoveryCsr1000vOspfImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -79,6 +80,10 @@ public class LinkDiscoveryCsr1000vOspfImpl extends AbstractHandlerBehaviour
      */
     private Set<LinkDescription> parseCsr1000vOspfLinks(HierarchicalConfiguration cfg) {
         Set<LinkDescription> links = new HashSet<>();
+        List<Object> ospfLinkInfo = cfg.getList("data.cli-oper-data-block.item.response");
+        for (int i = 0; i < ospfLinkInfo.size(); i++) {
+            log.info("OSPF neighbor: {}", ospfLinkInfo.get(i).toString());
+        }
 
         return links;
     }

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/PortGetterCsr1000vImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/PortGetterCsr1000vImpl.java
@@ -2,6 +2,7 @@ package org.onosproject.drivers.cisco;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.onlab.packet.MacAddress;
 import org.onosproject.drivers.utilities.XmlConfigParser;
 import org.onosproject.net.AnnotationKeys;
 import org.onosproject.net.DefaultAnnotations;
@@ -11,6 +12,7 @@ import org.onosproject.net.behaviour.PortDiscovery;
 import org.onosproject.net.device.DefaultPortDescription;
 import org.onosproject.net.device.PortDescription;
 import org.onosproject.net.driver.AbstractHandlerBehaviour;
+import org.onosproject.net.host.InterfaceIpAddress;
 import org.onosproject.netconf.NetconfController;
 import org.onosproject.netconf.NetconfException;
 import org.onosproject.netconf.NetconfSession;
@@ -55,8 +57,7 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
          */
 
         List<PortDescription> descriptions =
-                parseCsr1000vPorts(XmlConfigParser.
-                        loadXml(new ByteArrayInputStream(reply.getBytes())));
+                parseCsr1000vPorts(XmlConfigParser.loadXml(new ByteArrayInputStream(reply.getBytes())));
         return descriptions;
     }
 
@@ -77,7 +78,9 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
         rpc.append("</config-format-text-cmd>");
         rpc.append("<oper-data-format-text-block>");
         /* Use regular expression to extract status of the interfaces */
-        rpc.append("<exec>show interfaces | include (line protocol)|(Internet address is)|(BW [0-9]+ Kbit/sec)</exec>");
+        rpc.append("<exec>");
+        rpc.append("show interfaces | include (line protocol)|(bia)|(Internet address is)|(BW [0-9]+ Kbit/sec)");
+        rpc.append("</exec>");
         rpc.append("</oper-data-format-text-block>");
         rpc.append("</filter>");
         rpc.append("</get>");
@@ -96,7 +99,7 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
         List<Object> portNames = cfg.getList("data.cli-config-data.cmd");
         List<Object> portStatus = cfg.getList("data.cli-oper-data-block.item.response");
         int numberOfPorts = portNames.size();
-        if (portStatus.size() != numberOfPorts * 4 + 1) {
+        if (portStatus.size() != numberOfPorts * 5 + 1) {
             log.error("Failed to match portStatus against portName");
             return portDescriptions;
         }
@@ -105,23 +108,29 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
             PortNumber portNumber = PortNumber.portNumber(i + 1);
             /* Example string:
              *   GigabitEthernet1 is up, line protocol is up
-             *   Internet address is 192.168.0.4/24
-             *   MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
+             *     Hardware is CSR vNIC, address is 2cc2.6058.f7d5 (bia 2cc2.6058.f7d5)
+             *     Internet address is 192.168.0.4/24
+             *     MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
              *   GigabitEthernet2 is administratively down, line protocol is down
-             *   Internet address is 10.0.4.1/24
-             *   MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
+             *     Hardware is CSR vNIC, address is 2cc2.6058.f7d6 (bia 2cc2.6058.f7d6)
+             *     Internet address is 10.0.4.1/24
+             *     MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
              *
-             * with default delimiter ",", List<Object> portStatus will have size numberOfPorts * 4 + 1.
-             * Link status of port i is on (i * 4)th cell and link speed info of port i is on
-             * (i * 4 + 2)th cell.
+             * with default delimiter ",", List<Object> portStatus will have size numberOfPorts * 5 + 1.
+             * Status of port i is in (i * 5)th cell,
+             * MAC and IP address of port i are in (i * 5 + 2)th cell,
+             * and port speed info of port i is in (i * 5 + 3)th cell.
              */
-            boolean isEnabled = portStatus.get(i * 4).toString().contains("up");
-            String ipv4Address = getIpAddress(portStatus.get(i * 4 + 1).toString());
-            long portSpeed = getPortSpeed(portStatus.get(i * 4 + 2).toString());
-            DefaultAnnotations annotations = DefaultAnnotations.builder().
-                    set(AnnotationKeys.PORT_NAME, portNames.get(i).toString().replace("interface ", "")).
-                    set(AnnotationKeys.PORT_IP, ipv4Address).
-                    build();
+            boolean isEnabled = portStatus.get(i * 5).toString().contains("up");
+            MacAddress macAddress = getMacAddress(portStatus.get(i * 5 + 2).toString());
+            InterfaceIpAddress ipv4Address = getIpAddress(portStatus.get(i * 5 + 2).toString());
+            long portSpeed = getPortSpeed(portStatus.get(i * 5 + 3).toString());
+
+            DefaultAnnotations annotations = DefaultAnnotations.builder()
+                    .set(AnnotationKeys.PORT_NAME, portNames.get(i).toString().replace("interface ", ""))
+                    .set(AnnotationKeys.PORT_MAC, macAddress.toString())
+                    .set(AnnotationKeys.PORT_IP, ipv4Address.toString())
+                    .build();
             portDescriptions.add(new DefaultPortDescription(portNumber, isEnabled, Port.Type.COPPER, portSpeed,
                     annotations));
         }
@@ -133,15 +142,37 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
         return Long.parseLong(str.split("BW ")[1].split(" Kbit/sec")[0]) / 1000;
     }
 
-    private static String getIpAddress(String str) {
-        /* Example string: line protocol is up Internet address is 192.168.0.4/24 MTU 1500 bytes */
+    private static MacAddress getMacAddress(String str) {
+        /* Example string:
+         *   address is 2cc2.6058.f7d5 (bia 2cc2.6058.f7d5)
+         *   Internet address is 192.168.0.4/24
+         *   MTU 1500 bytes
+         */
+        String macPattern = "([0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4})";
+        Pattern pattern = Pattern.compile(macPattern);
+        Matcher matcher = pattern.matcher(str);
+
+        if (matcher.find()) {   // though there are two matches, return only the first one
+            long address = Long.parseLong(matcher.group().replace(".", ""), 16);
+            // remove "." and parse it as a long integer
+            return MacAddress.valueOf(address);
+        }
+        return MacAddress.ZERO;
+    }
+
+    private static InterfaceIpAddress getIpAddress(String str) {
+        /* Example string:
+         *   address is 2cc2.6058.f7d5 (bia 2cc2.6058.f7d5)
+         *   Internet address is 192.168.0.4/24
+         *   MTU 1500 bytes
+         */
         String ipv4Pattern = "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})/(\\d{1,2})";
         Pattern pattern = Pattern.compile(ipv4Pattern);
         Matcher matcher = pattern.matcher(str);
 
         if (matcher.find()) {
-            return matcher.group();
+            return InterfaceIpAddress.valueOf(matcher.group());
         }
-        return "0.0.0.0/0";
+        return InterfaceIpAddress.valueOf("0.0.0.0/0");
     }
 }

--- a/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/PortGetterCsr1000vImpl.java
+++ b/drivers/cisco/src/main/java/org/onosproject/drivers/cisco/PortGetterCsr1000vImpl.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -75,7 +77,7 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
         rpc.append("</config-format-text-cmd>");
         rpc.append("<oper-data-format-text-block>");
         /* Use regular expression to extract status of the interfaces */
-        rpc.append("<exec>show interfaces | include (line protocol)|(BW [0-9]+ Kbit/sec)</exec>");
+        rpc.append("<exec>show interfaces | include (line protocol)|(Internet address is)|(BW [0-9]+ Kbit/sec)</exec>");
         rpc.append("</oper-data-format-text-block>");
         rpc.append("</filter>");
         rpc.append("</get>");
@@ -103,8 +105,10 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
             PortNumber portNumber = PortNumber.portNumber(i + 1);
             /* Example string:
              *   GigabitEthernet1 is up, line protocol is up
+             *   Internet address is 192.168.0.4/24
              *   MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
              *   GigabitEthernet2 is administratively down, line protocol is down
+             *   Internet address is 10.0.4.1/24
              *   MTU 1500 bytes, BW 1000000 Kbit/sec, DLY 10 usec,
              *
              * with default delimiter ",", List<Object> portStatus will have size numberOfPorts * 4 + 1.
@@ -112,9 +116,11 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
              * (i * 4 + 2)th cell.
              */
             boolean isEnabled = portStatus.get(i * 4).toString().contains("up");
+            String ipv4Address = getIpAddress(portStatus.get(i * 4 + 1).toString());
             long portSpeed = getPortSpeed(portStatus.get(i * 4 + 2).toString());
             DefaultAnnotations annotations = DefaultAnnotations.builder().
                     set(AnnotationKeys.PORT_NAME, portNames.get(i).toString().replace("interface ", "")).
+                    set(AnnotationKeys.PORT_IP, ipv4Address).
                     build();
             portDescriptions.add(new DefaultPortDescription(portNumber, isEnabled, Port.Type.COPPER, portSpeed,
                     annotations));
@@ -125,5 +131,17 @@ public class PortGetterCsr1000vImpl extends AbstractHandlerBehaviour
     private static long getPortSpeed(String str) {
         /* Example string: BW 1000000 Kbit/sec */
         return Long.parseLong(str.split("BW ")[1].split(" Kbit/sec")[0]) / 1000;
+    }
+
+    private static String getIpAddress(String str) {
+        /* Example string: line protocol is up Internet address is 192.168.0.4/24 MTU 1500 bytes */
+        String ipv4Pattern = "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})/(\\d{1,2})";
+        Pattern pattern = Pattern.compile(ipv4Pattern);
+        Matcher matcher = pattern.matcher(str);
+
+        if (matcher.find()) {
+            return matcher.group();
+        }
+        return "0.0.0.0/0";
     }
 }

--- a/drivers/cisco/src/main/resources/cisco-drivers.xml
+++ b/drivers/cisco/src/main/resources/cisco-drivers.xml
@@ -32,5 +32,7 @@
                    impl="org.onosproject.drivers.cisco.PortStatsQueryCsr1000vImpl"/>
         <behaviour api="org.onosproject.net.behaviour.ConfigSetter"
                    impl="org.onosproject.drivers.cisco.ConfigSetterCsr1000vImpl"/>
+        <behaviour api="org.onosproject.net.behaviour.LinkDiscovery"
+                   impl="org.onosproject.drivers.cisco.LinkDiscoveryCsr1000vOspfImpl"/>
     </driver>
 </drivers>

--- a/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
+++ b/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
@@ -364,20 +364,17 @@ public class NetconfDeviceProvider extends AbstractProvider
         if (device.is(LinkDiscovery.class)) {
             LinkDiscovery linkDiscovery = device.as(LinkDiscovery.class);
             Set<LinkDescription> aliveLinkDescriptions = linkDiscovery.getLinks();
+
+            Preconditions.checkNotNull(aliveLinkDescriptions, "aliveLinkDescription is null");
+
             /* Update alive links */
-            if (aliveLinkDescriptions != null) {
-                for (LinkDescription desc : aliveLinkDescriptions) {
-                    linkProviderService.linkDetected(desc);
-                }
-            }
+            aliveLinkDescriptions.forEach(desc -> linkProviderService.linkDetected(desc));
+
             /* Remove vanished links */
-            Set<LinkDescription> vanishedLinkDescription = linkDescriptionsOfDevice.get(deviceId);
-            vanishedLinkDescription.removeAll(aliveLinkDescriptions);
-            if (!vanishedLinkDescription.isEmpty()) {
-                for (LinkDescription desc : vanishedLinkDescription) {
-                    linkProviderService.linkVanished(desc);
-                }
-            }
+            Set<LinkDescription> vanishedLinkDescriptions = linkDescriptionsOfDevice.get(deviceId);
+            vanishedLinkDescriptions.removeAll(aliveLinkDescriptions);
+            vanishedLinkDescriptions.forEach(desc -> linkProviderService.linkVanished(desc));
+
             /* Track alive links */
             linkDescriptionsOfDevice.put(deviceId, aliveLinkDescriptions);
         } else {

--- a/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
+++ b/providers/netconf/device/src/main/java/org/onosproject/provider/netconf/device/impl/NetconfDeviceProvider.java
@@ -52,6 +52,7 @@ import org.onosproject.net.device.DeviceProvider;
 import org.onosproject.net.device.DeviceProviderRegistry;
 import org.onosproject.net.device.DeviceProviderService;
 import org.onosproject.net.device.DeviceService;
+import org.onosproject.net.device.PortDescription;
 import org.onosproject.net.device.PortStatistics;
 import org.onosproject.net.key.DeviceKey;
 import org.onosproject.net.key.DeviceKeyAdminService;
@@ -75,6 +76,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -534,16 +536,19 @@ public class NetconfDeviceProvider extends AbstractProvider
 
     private void discoverPorts(DeviceId deviceId) {
         Device device = deviceService.getDevice(deviceId);
+        List<PortDescription> portDescsriptions;
         //TODO remove when PortDiscovery is removed from master
         if (device.is(PortDiscovery.class)) {
             PortDiscovery portConfig = device.as(PortDiscovery.class);
+            portDescsriptions = portConfig.getPorts();
             providerService.updatePorts(deviceId,
-                                        portConfig.getPorts());
+                                        portDescsriptions);
         } else if (device.is(DeviceDescriptionDiscovery.class)) {
             DeviceDescriptionDiscovery deviceDescriptionDiscovery =
                     device.as(DeviceDescriptionDiscovery.class);
+            portDescsriptions = deviceDescriptionDiscovery.discoverPortDetails();
             providerService.updatePorts(deviceId,
-                                        deviceDescriptionDiscovery.discoverPortDetails());
+                                        portDescsriptions);
         } else {
             log.warn("No portGetter behaviour for device {}", deviceId);
         }


### PR DESCRIPTION
Make `NetconfDeviceProvider` also a `LinkProvider`. It now supports link discovery by having routers report links discovered through OSPF hello messages. Links are polled every 30 seconds by default.

`pollingInterval` property configuration is removed intentionally since ONOS-1.7.0 changed scheduler implementation in `NetconfDeviceProvider` and I think we should re-implement `pollingInterval` property in a more elegant way.

@thiagoss, @victorssilva, @DanielCMS, and @ningw, please review the changes if convenient.
cc. @gushchinav, @archit.
